### PR TITLE
Only consider effective dependencies

### DIFF
--- a/internal/gocmd/gocmd.go
+++ b/internal/gocmd/gocmd.go
@@ -58,8 +58,14 @@ func ListVendoredModules(modulePath string, writer io.Writer) error {
 
 // ListPackageDependencies executed `go list -deps -json` and writes the output to a given writer.
 // See https://golang.org/cmd/go/#hdr-List_packages_or_modules
-func ListPackageDependencies(modulePath, packagePath string, writer io.Writer) error {
-	cmd := exec.Command("go", "list", "-deps", "-json", filepath.Join(modulePath, packagePath))
+func ListPackageDependencies(modulePath, packagePath string, test bool, writer io.Writer) error {
+	args := []string{"list", "-mod", "readonly", "-deps", "-json"}
+	if test {
+		args = append(args, "-test")
+	}
+	args = append(args, filepath.Join(modulePath, packagePath))
+
+	cmd := exec.Command("go", args...)
 	cmd.Dir = modulePath
 	cmd.Stdout = writer
 	return cmd.Run()

--- a/internal/gocmd/gocmd.go
+++ b/internal/gocmd/gocmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -55,23 +56,20 @@ func ListVendoredModules(modulePath string, writer io.Writer) error {
 	return cmd.Run()
 }
 
+// ListPackageDependencies executed `go list -deps -json` and writes the output to a given writer.
+// See https://golang.org/cmd/go/#hdr-List_packages_or_modules
+func ListPackageDependencies(modulePath, packagePath string, writer io.Writer) error {
+	cmd := exec.Command("go", "list", "-deps", "-json", filepath.Join(modulePath, packagePath))
+	cmd.Dir = modulePath
+	cmd.Stdout = writer
+	return cmd.Run()
+}
+
 // GetModuleGraph executes `go mod graph` and writes the output to a given writer.
 // See https://golang.org/ref/mod#go-mod-graph
 func GetModuleGraph(modulePath string, writer io.Writer) error {
 	cmd := exec.Command("go", "mod", "graph")
 	cmd.Dir = modulePath
 	cmd.Stdout = writer
-	return cmd.Run()
-}
-
-func ModDownload(modulePath string) error {
-	cmd := exec.Command("go", "mod", "download")
-	cmd.Dir = modulePath
-	return cmd.Run()
-}
-
-func ModTidy(modulePath string) error {
-	cmd := exec.Command("go", "mod", "tidy")
-	cmd.Dir = modulePath
 	return cmd.Run()
 }

--- a/internal/gomod/package.go
+++ b/internal/gomod/package.go
@@ -1,0 +1,35 @@
+package gomod
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+// Package represents parts of the struct that `go list` is working with.
+// See https://golang.org/cmd/go/#hdr-List_packages_or_modules
+type Package struct {
+	ImportPath string  // directory containing package sources
+	Name       string  // package name
+	Standard   bool    // is this package part of the standard Go library?
+	Module     *Module // info about package's containing module, if any (can be nil)
+}
+
+// parsePackages parses the output of `go list [-deps] -json` into a Package slice.
+func parsePackages(reader io.Reader) ([]Package, error) {
+	packages := make([]Package, 0)
+	jsonDecoder := json.NewDecoder(reader)
+
+	// Output is not a JSON array, so we have to parse one object after another
+	for {
+		var pkg Package
+		if err := jsonDecoder.Decode(&pkg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		packages = append(packages, pkg)
+	}
+	return packages, nil
+}

--- a/internal/gomod/package.go
+++ b/internal/gomod/package.go
@@ -15,7 +15,7 @@ type Package struct {
 	Module     *Module // info about package's containing module, if any (can be nil)
 }
 
-// parsePackages parses the output of `go list [-deps] -json` into a Package slice.
+// parsePackages parses the output of `go list -json` into a Package slice.
 func parsePackages(reader io.Reader) ([]Package, error) {
 	packages := make([]Package, 0)
 	jsonDecoder := json.NewDecoder(reader)

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -25,6 +25,7 @@ import (
 type GenerateOptions struct {
 	ComponentType   cdx.ComponentType
 	IncludeStdLib   bool
+	IncludeTest     bool
 	NoSerialNumber  bool
 	NoVersionPrefix bool
 	PackagePath     string
@@ -35,7 +36,7 @@ type GenerateOptions struct {
 
 func Generate(modulePath string, options GenerateOptions) (*cdx.BOM, error) {
 	log.Println("enumerating modules")
-	modules, err := gomod.GetModules(modulePath, options.PackagePath)
+	modules, err := gomod.GetModules(modulePath, options.PackagePath, options.IncludeTest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to enumerate modules: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ type Options struct {
 	ComponentType    cdx.ComponentType
 	ComponentTypeStr string
 	IncludeStd       bool
+	IncludeTest      bool
 	ModulePath       string
 	NoSerialNumber   bool
 	NoVersionPrefix  bool
@@ -37,6 +38,7 @@ func main() {
 
 	flag.StringVar(&options.ComponentTypeStr, "type", string(cdx.ComponentTypeApplication), "Type of the main component")
 	flag.BoolVar(&options.IncludeStd, "std", false, "Include Go standard library as component and dependency of the module")
+	flag.BoolVar(&options.IncludeTest, "test", false, "Include test modules")
 	flag.StringVar(&options.ModulePath, "module", ".", "Path to Go module")
 	flag.BoolVar(&options.NoSerialNumber, "noserial", false, "Omit serial number")
 	flag.BoolVar(&options.NoVersionPrefix, "novprefix", false, "Omit \"v\" version prefix")
@@ -112,6 +114,7 @@ func executeCommand(options Options) error {
 	bom, err := sbom.Generate(options.ModulePath, sbom.GenerateOptions{
 		ComponentType:   options.ComponentType,
 		IncludeStdLib:   options.IncludeStd,
+		IncludeTest:     options.IncludeTest,
 		NoSerialNumber:  options.NoSerialNumber,
 		NoVersionPrefix: options.NoVersionPrefix,
 		PackagePath:     options.PackagePath,

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/CycloneDX/cyclonedx-gomod/internal/sbom"
@@ -22,6 +23,7 @@ type Options struct {
 	NoSerialNumber   bool
 	NoVersionPrefix  bool
 	OutputPath       string
+	PackagePath      string
 	ResolveLicenses  bool
 	Reproducible     bool
 	SerialNumber     *uuid.UUID
@@ -39,6 +41,7 @@ func main() {
 	flag.BoolVar(&options.NoSerialNumber, "noserial", false, "Omit serial number")
 	flag.BoolVar(&options.NoVersionPrefix, "novprefix", false, "Omit \"v\" version prefix")
 	flag.StringVar(&options.OutputPath, "output", "-", "Output path")
+	flag.StringVar(&options.PackagePath, "package", "...", "Package path") // TODO: add better usage text
 	flag.BoolVar(&options.ResolveLicenses, "licenses", false, "Resolve module licenses")
 	flag.BoolVar(&options.Reproducible, "reproducible", false, "Make the SBOM reproducible by omitting dynamic content")
 	flag.StringVar(&options.SerialNumberStr, "serial", "", "Serial number (default [random UUID])")
@@ -94,6 +97,13 @@ func validateOptions(options *Options) error {
 		}
 	}
 
+	if options.ModulePath == "." {
+		abs, _ := filepath.Abs(options.ModulePath)
+		options.ModulePath = abs
+	}
+
+	// TODO: verify that PackagePath is either "all", "...", relative to ModulePath or an absolute path to a subdirectory of ModulePath
+
 	return nil
 }
 
@@ -104,6 +114,7 @@ func executeCommand(options Options) error {
 		IncludeStdLib:   options.IncludeStd,
 		NoSerialNumber:  options.NoSerialNumber,
 		NoVersionPrefix: options.NoVersionPrefix,
+		PackagePath:     options.PackagePath,
 		Reproducible:    options.Reproducible,
 		ResolveLicenses: options.ResolveLicenses,
 		SerialNumber:    options.SerialNumber,


### PR DESCRIPTION
Addresses #20 

- [x] Use `go list -deps` instead of `go list -m` to enumerate module dependencies
  * See https://github.com/CycloneDX/cyclonedx-gomod/issues/20#issuecomment-846470755
- [ ] Add option to only consider a specific package (including its transitive dependencies)
  * If no specific package is provided, `all` or `./...` is assumed
  * Providing multiple packages would technically be possible, but I don't see any use-case for this, as `-deps` is already recursive
  * Main use-case: multiple commands / applications in a single module, e.g. `cmd/server` and `cmd/client`
  * How can we express this in the BOM? Possibly via subpath in the PURL, e.g. `pkg:golang/github.com/sigstore/cosign@v0.4.0#cmd/cosign`?
- [ ] Add option to include test-only dependencies of the selected packages
  * Seems like `go list -deps -test` does this
- [ ] Ensure / investigate compatibility / synergy with vendored modules
  * First tests indicate that `go list -deps` works with `-mod=vendor` as well, maybe we can remove the current vendor-specific logic?
- [ ] Update documentation
  * Make sure to mention Influence of `GOOS`, `GOARCH` and build tags
  * This is going to be a breaking change, as **a lot** of modules won't show up in BOMs anymore
- [ ] Update release workflow
  * Generate and attach a BOM for each binary

Things to research:

- [ ] Is the behavior of `go list -deps` consitent across Go versions? What's the oldest version that implements this?