### PR TITLE
Remove version normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ FLAGS
   -licenses=false      Resolve module licenses
   -main main.go        Path to the application's main file, relative to MODPATH
   -noserial=false      Omit serial number
-  -novprefix=false     Omit "v" prefix from versions
   -output -            Output file path (or - for STDOUT)
   -reproducible=false  Make the SBOM reproducible by omitting dynamic content
   -serial ...          Serial number
@@ -116,7 +115,6 @@ FLAGS
   -json=false          Output in JSON
   -licenses=false      Resolve module licenses
   -noserial=false      Omit serial number
-  -novprefix=false     Omit "v" prefix from versions
   -output -            Output file path (or - for STDOUT)
   -reproducible=false  Make the SBOM reproducible by omitting dynamic content
   -serial ...          Serial number
@@ -141,7 +139,6 @@ FLAGS
   -json=false          Output in JSON
   -licenses=false      Resolve module licenses
   -noserial=false      Omit serial number
-  -novprefix=false     Omit "v" prefix from versions
   -output -            Output file path (or - for STDOUT)
   -reproducible=false  Make the SBOM reproducible by omitting dynamic content
   -serial ...          Serial number

--- a/internal/cli/cmd/app/app.go
+++ b/internal/cli/cmd/app/app.go
@@ -111,8 +111,6 @@ func Exec(options Options) error {
 		return err
 	}
 
-	sbom.NormalizeVersions(modules, options.NoVersionPrefix)
-
 	mainComponent, err := modconv.ToComponent(modules[0],
 		modconv.WithComponentType(cdx.ComponentTypeApplication),
 		modconv.WithFiles(options.IncludeFiles),

--- a/internal/cli/cmd/app/app_test.go
+++ b/internal/cli/cmd/app/app_test.go
@@ -1,3 +1,20 @@
+// This file is part of CycloneDX GoMod
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
 package app
 
 import (

--- a/internal/cli/cmd/app/options_test.go
+++ b/internal/cli/cmd/app/options_test.go
@@ -1,3 +1,20 @@
+// This file is part of CycloneDX GoMod
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
 package app
 
 import (

--- a/internal/cli/cmd/bin/bin.go
+++ b/internal/cli/cmd/bin/bin.go
@@ -47,6 +47,8 @@ func New() *ffcli.Command {
 
 When license resolution is enabled, all modules (including the main module) 
 will be downloaded to the module cache using "go mod download".
+For the download of the main module to work, its version has to be provided
+via the -version flag.
 
 Please note that data embedded in binaries shouldn't be trusted,
 unless there's solid evidence that the binaries haven't been modified
@@ -91,8 +93,6 @@ func Exec(binOptions BinOptions) error {
 			return err
 		}
 	}
-
-	sbom.NormalizeVersions(modules, binOptions.NoVersionPrefix)
 
 	// Make all modules a direct dependency of the main module
 	for i := 1; i < len(modules); i++ {

--- a/internal/cli/cmd/mod/mod.go
+++ b/internal/cli/cmd/mod/mod.go
@@ -102,8 +102,6 @@ func Exec(options ModOptions) error {
 		log.Warn().Err(err).Msg("failed to determine version of main module")
 	}
 
-	sbom.NormalizeVersions(modules, options.NoVersionPrefix)
-
 	mainComponent, err := modconv.ToComponent(modules[0],
 		modconv.WithComponentType(cdx.ComponentType(options.ComponentType)),
 		modconv.WithLicenses(options.ResolveLicenses),

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -66,7 +66,6 @@ func (o OutputOptions) Validate() error {
 type SBOMOptions struct {
 	IncludeStd      bool
 	NoSerialNumber  bool
-	NoVersionPrefix bool
 	Reproducible    bool
 	ResolveLicenses bool
 	SerialNumber    string
@@ -75,7 +74,6 @@ type SBOMOptions struct {
 func (s *SBOMOptions) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.IncludeStd, "std", false, "Include Go standard library as component and dependency of the module")
 	fs.BoolVar(&s.NoSerialNumber, "noserial", false, "Omit serial number")
-	fs.BoolVar(&s.NoVersionPrefix, "novprefix", false, "Omit \"v\" prefix from versions")
 	fs.BoolVar(&s.Reproducible, "reproducible", false, "Make the SBOM reproducible by omitting dynamic content")
 	fs.BoolVar(&s.ResolveLicenses, "licenses", false, "Resolve module licenses")
 	fs.StringVar(&s.SerialNumber, "serial", "", "Serial number")

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -188,21 +188,3 @@ func NewProperty(name, value string) cdx.Property {
 		Value: value,
 	}
 }
-
-func NormalizeVersions(modules []gomod.Module, trimPrefix bool) {
-	for i, module := range modules {
-		NormalizeVersion(&modules[i], trimPrefix)
-
-		if module.Replace != nil {
-			NormalizeVersion(modules[i].Replace, trimPrefix)
-		}
-	}
-}
-
-func NormalizeVersion(module *gomod.Module, trimPrefix bool) {
-	module.Version = strings.TrimSuffix(module.Version, "+incompatible")
-
-	if trimPrefix {
-		module.Version = strings.TrimPrefix(module.Version, "v")
-	}
-}

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/CycloneDX/cyclonedx-gomod/internal/gomod"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,24 +76,4 @@ func TestNewProperty(t *testing.T) {
 	property := NewProperty("name", "value")
 	require.Equal(t, "cdx:gomod:name", property.Name)
 	require.Equal(t, "value", property.Value)
-}
-
-func TestNormalizeVersion(t *testing.T) {
-	t.Run("With trimPrefix", func(t *testing.T) {
-		module := gomod.Module{
-			Version: "v1.0.0+incompatible",
-		}
-
-		NormalizeVersion(&module, true)
-		require.Equal(t, "1.0.0", module.Version)
-	})
-
-	t.Run("Without trimPrefix", func(t *testing.T) {
-		module := gomod.Module{
-			Version: "v1.0.0+incompatible",
-		}
-
-		NormalizeVersion(&module, false)
-		require.Equal(t, "v1.0.0", module.Version)
-	})
 }


### PR DESCRIPTION
Both the `v` prefix as well as the `+incompatible` suffix are parts of the actual version.

Removing them as part of "version normalization" was done to ensure compatibility with vulnerability scanners like OSS Index, which can't deal with the `v` prefix (https://github.com/OSSIndex/vulns/issues/129#issuecomment-740666614). 

I have been reflecting on this, and I don't believe this implementation should be concerned with shortcomings of some scanner. If anything, ensuring correct version formatting should be a concern of OSS Index users (or clients, like OWASP Dependency-Track).