### PR TITLE
build(deps): bump golang base images from 1.17.2 to 1.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.17.2-alpine3.14@sha256:5519c8752f6b53fc8818dc46e9fda628c99c4e8fd2d2f1df71e1f184e71f47dc as build
+FROM golang:1.17.3-alpine3.14@sha256:7bd9bf011a76c21b70a1e507de7f8d67656e1f293fd72af80aa46f7b054db515 as build
 ARG VERSION=latest
 WORKDIR /tmp/cyclonedx-gomod
 RUN apk --no-cache add git make
 COPY . .
 RUN make install
 
-FROM golang:1.17.2-alpine3.14@sha256:5519c8752f6b53fc8818dc46e9fda628c99c4e8fd2d2f1df71e1f184e71f47dc
+FROM golang:1.17.3-alpine3.14@sha256:7bd9bf011a76c21b70a1e507de7f8d67656e1f293fd72af80aa46f7b054db515
 COPY --from=build /go/bin/cyclonedx-gomod /usr/local/bin/
 USER 1000
 ENTRYPOINT ["cyclonedx-gomod"]

--- a/Dockerfile.examples
+++ b/Dockerfile.examples
@@ -10,7 +10,7 @@
 # for linux/amd64. If you're on a different platform, you'll have to run
 #   GOOS=linux GOARCH=amd64 make examples-image
 # instead.
-FROM golang:1.17.2-bullseye@sha256:ac20397fcb5b8bcc0df870c41d1f6b102c897f686ba85d982287494651a7e7b5
+FROM golang:1.17.3-bullseye@sha256:2d7e51a4f0f0ae1dea6e57e544f2bc74174fc200269e1b99570f4fa4d847817e
 
 VOLUME /examples
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 # This Dockerfile is meant for GoReleaser exclusively, see .goreleaser.yml.
 # For manual builds, please use the regular Dockerfile or simply run "make docker".
-FROM golang:1.17.2-alpine3.14@sha256:5519c8752f6b53fc8818dc46e9fda628c99c4e8fd2d2f1df71e1f184e71f47dc
+FROM golang:1.17.3-alpine3.14@sha256:7bd9bf011a76c21b70a1e507de7f8d67656e1f293fd72af80aa46f7b054db515
 COPY cyclonedx-gomod /usr/local/bin/
 USER 1000
 ENTRYPOINT ["cyclonedx-gomod"]


### PR DESCRIPTION
Supersedes #94, because dependabot is incapable of differenciating between alpine- and debian-based image.