### PR TITLE
fix: `nolint` directive for `exhaustive` changed

### DIFF
--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -149,7 +149,7 @@ func CalculateFileHashes(logger zerolog.Logger, filePath string, algos ...cdx.Ha
 	for _, algo := range algos {
 		var hashWriter hash.Hash
 
-		switch algo { //exhaustive:ignore
+		switch algo { //nolint:exhaustive
 		case cdx.HashAlgoMD5:
 			hashWriter = md5.New() // #nosec G401
 		case cdx.HashAlgoSHA1:


### PR DESCRIPTION
Signed-off-by: nscuro <nscuro@protonmail.com>