### PR TITLE
fix: errors being logged in json format when they shouldn't

### DIFF
--- a/cmd/cyclonedx-gomod/main.go
+++ b/cmd/cyclonedx-gomod/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/rs/zerolog"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -34,7 +35,12 @@ func main() {
 		if _, ok := err.(*options.ValidationError); ok {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 		} else {
-			log.Err(err).Msg("")
+			logger := log.Output(zerolog.ConsoleWriter{
+				Out:     os.Stderr,
+				NoColor: os.Getenv("CI") != "",
+			})
+
+			logger.Err(err).Msg("")
 		}
 		os.Exit(1)
 	}

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -52,20 +52,6 @@ type LogOptions struct {
 	Verbose bool
 }
 
-// ConfigureLogger configures the global logger according to LogOptions.
-func (l LogOptions) ConfigureLogger() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{
-		Out:     os.Stderr,
-		NoColor: os.Getenv("CI") != "",
-	})
-
-	if l.Verbose {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	} else {
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	}
-}
-
 // Logger returns a zerolog.Logger configured according to LogOptions.
 func (l LogOptions) Logger() zerolog.Logger {
 	logger := log.Output(zerolog.ConsoleWriter{


### PR DESCRIPTION
before:

```
4:07PM DBG executing command cmd="/usr/local/go/bin/go mod why -m -vendor github.com/CycloneDX/cyclonedx-go" dir=/work
4:07PM DBG failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
{"level":"error","error":"failed to download modules: command `/usr/local/go/bin/go mod why -m -vendor github.com/CycloneDX/cyclonedx-go` failed: exit status 1","time":"2023-08-03T16:07:49Z"}
```

after:

```
4:05PM DBG executing command cmd="/usr/local/go/bin/go mod why -m -vendor github.com/CycloneDX/cyclonedx-go" dir=/work
4:05PM DBG failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
4:05PM ERR error="failed to download modules: command `/usr/local/go/bin/go mod why -m -vendor github.com/CycloneDX/cyclonedx-go` failed: exit status 1"
```