### PR TITLE
fix: permission denied for `/.cache/go-build` in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ COPY . .
 RUN make install
 
 FROM golang:1.20.4-alpine3.16@sha256:6469405d7297f82d56195c90a3270b0806ef4bd897aa0628477d9959ab97a577
+# When running as non-root user, GOCACHE must be set to a directory
+# that is writable by that user. It will otherwise default to /.cache/go-build,
+# which is owned by root.
+# https://github.com/golang/go/issues/26280#issuecomment-445294378
+ENV GOCACHE=/tmp/go-build
 COPY --from=build /go/bin/cyclonedx-gomod /usr/local/bin/
 USER 1000
 ENTRYPOINT ["cyclonedx-gomod"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,11 @@
 # This Dockerfile is meant for GoReleaser exclusively, see .goreleaser.yml.
 # For manual builds, please use the regular Dockerfile or simply run "make docker".
 FROM golang:1.20.4-alpine3.16@sha256:6469405d7297f82d56195c90a3270b0806ef4bd897aa0628477d9959ab97a577
+# When running as non-root user, GOCACHE must be set to a directory
+# that is writable by that user. It will otherwise default to /.cache/go-build,
+# which is owned by root.
+# https://github.com/golang/go/issues/26280#issuecomment-445294378
+ENV GOCACHE=/tmp/go-build
 COPY cyclonedx-gomod /usr/local/bin/
 USER 1000
 ENTRYPOINT ["cyclonedx-gomod"]


### PR DESCRIPTION
caused by https://github.com/golang/go/issues/26280#issuecomment-445294378

relates to https://github.com/CycloneDX/cyclonedx-gomod/issues/230