### PR TITLE
chore: raise baseline go version to `1.20`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # tag=v4.1.0
       with:
-        go-version: "1.20"
+        go-version: "1.21"
         check-latest: true
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # tag=v3.7.0
@@ -59,7 +59,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # tag=v4.1.0
       with:
-        go-version: "1.20"
+        go-version: "1.21"
         check-latest: true
     - name: Setup CycloneDX CLI
       run: |

--- a/.github/workflows/goreleaser-ci.yml
+++ b/.github/workflows/goreleaser-ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # tag=v4.1.0
       with:
-        go-version: "1.20"
+        go-version: "1.21"
         check-latest: true
     - name: Set up QEMU
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # tag=v3.0.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # tag=v4.1.0
       with:
-        go-version: "1.20"
+        go-version: "1.21"
         check-latest: true
     - uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # tag=v2.8.1
     - name: Set up QEMU

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ brew install cyclonedx/cyclonedx/cyclonedx-gomod
 go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
 ```
 
-Building from source requires Go 1.18 or newer.
+Building from source requires Go 1.20 or newer.
 
 ## Compatibility
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CycloneDX/cyclonedx-gomod
 
-go 1.18
+go 1.20
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1


### PR DESCRIPTION
and build against go `1.21` in ci