### PR TITLE
feat: cli option to disable html escaping in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,19 +132,20 @@ Examples:
   $ cyclonedx-gomod app -json -output acme-app.bom.json -packages -files -licenses -main cmd/acme-app /usr/src/acme-module
 
 FLAGS
-  -assert-licenses=false  Assert detected licenses
-  -files=false            Include files
-  -json=false             Output in JSON
-  -licenses=false         Perform license detection
-  -main string            Path to the application's main package, relative to MODULE_PATH
-  -noserial=false         Omit serial number
-  -output -               Output file path (or - for STDOUT)
-  -output-version 1.6     Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -packages=false         Include packages
-  -paths=false            Include file paths relative to their module root
-  -serial string          Serial number
-  -std=false              Include Go standard library as component and dependency of the module
-  -verbose=false          Enable verbose output
+  -assert-licenses=false       Assert detected licenses
+  -files=false                 Include files
+  -json=false                  Output in JSON
+  -disable-html-escape=false   Disable HTML escaping in JSON output
+  -licenses=false              Perform license detection
+  -main string                 Path to the application's main package, relative to MODULE_PATH
+  -noserial=false              Omit serial number
+  -output -                    Output file path (or - for STDOUT)
+  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -packages=false              Include packages
+  -paths=false                 Include file paths relative to their module root
+  -serial string               Serial number
+  -std=false                   Include Go standard library as component and dependency of the module
+  -verbose=false               Enable verbose output
 ```
 
 #### `bin`
@@ -179,16 +180,17 @@ Example:
   $ cyclonedx-gomod bin -json -output acme-app-v1.0.0.bom.json -version v1.0.0 ./acme-app
 
 FLAGS
-  -assert-licenses=false  Assert detected licenses
-  -json=false             Output in JSON
-  -licenses=false         Perform license detection
-  -noserial=false         Omit serial number
-  -output -               Output file path (or - for STDOUT)
-  -output-version 1.6     Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -serial string          Serial number
-  -std=false              Include Go standard library as component and dependency of the module
-  -verbose=false          Enable verbose output
-  -version string         Version of the main component
+  -assert-licenses=false       Assert detected licenses
+  -json=false                  Output in JSON
+  -disable-html-escape=false   Disable HTML escaping in JSON output
+  -licenses=false              Perform license detection
+  -noserial=false              Omit serial number
+  -output -                    Output file path (or - for STDOUT)
+  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -serial string               Serial number
+  -std=false                   Include Go standard library as component and dependency of the module
+  -verbose=false               Enable verbose output
+  -version string              Version of the main component
 ```
 
 #### `mod`
@@ -212,17 +214,18 @@ Examples:
   $ cyclonedx-gomod mod -test -output bom.xml ./cyclonedx-go
 
 FLAGS
-  -assert-licenses=false  Assert detected licenses
-  -json=false             Output in JSON
-  -licenses=false         Perform license detection
-  -noserial=false         Omit serial number
-  -output -               Output file path (or - for STDOUT)
-  -output-version 1.6     Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -serial string          Serial number
-  -std=false              Include Go standard library as component and dependency of the module
-  -test=false             Include test dependencies
-  -type application       Type of the main component
-  -verbose=false          Enable verbose output
+  -assert-licenses=false       Assert detected licenses
+  -json=false                  Output in JSON
+  -disable-html-escape=false   Disable HTML escaping in JSON output
+  -licenses=false              Perform license detection
+  -noserial=false              Omit serial number
+  -output -                    Output file path (or - for STDOUT)
+  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -serial string               Serial number
+  -std=false                   Include Go standard library as component and dependency of the module
+  -test=false                  Include test dependencies
+  -type application            Type of the main component
+  -verbose=false               Enable verbose output
 ```
 
 ### Examples 📃

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -78,9 +78,9 @@ func (l LogOptions) Validate() error {
 
 // OutputOptions provides options for customizing the output.
 type OutputOptions struct {
-	OutputFilePath string
-	OutputVersion  string
-	UseJSON        bool
+	OutputFilePath    string
+	OutputVersion     string
+	UseJSON           bool
 	DisableHTMLEscape bool
 }
 

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -81,6 +81,7 @@ type OutputOptions struct {
 	OutputFilePath string
 	OutputVersion  string
 	UseJSON        bool
+	DisableHTMLEscape bool
 }
 
 func (o *OutputOptions) RegisterFlags(fs *flag.FlagSet) {
@@ -98,6 +99,7 @@ func (o *OutputOptions) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.OutputFilePath, "output", "-", "Output file path (or - for STDOUT)")
 	fs.StringVar(&o.OutputVersion, "output-version", cdx.SpecVersion1_6.String(),
 		fmt.Sprintf("Output spec verson (%s)", strings.Join(versionChoices, ", ")))
+	fs.BoolVar(&o.DisableHTMLEscape, "disable-html-escape", false, "Disable HTML escaping in JSON output")
 }
 
 func (o OutputOptions) Validate() error {

--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -98,6 +98,10 @@ func WriteBOM(bom *cdx.BOM, outputOptions options.OutputOptions) error {
 	encoder := cdx.NewBOMEncoder(outputWriter, outputFormat)
 	encoder.SetPretty(true)
 
+	if(outputOptions.DisableHTMLEscape) {
+		encoder.SetEscapeHTML(false)
+	}	
+
 	if err := encoder.EncodeVersion(bom, outputVersion); err != nil {
 		return fmt.Errorf("failed to encode sbom: %w", err)
 	}

--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -98,9 +98,9 @@ func WriteBOM(bom *cdx.BOM, outputOptions options.OutputOptions) error {
 	encoder := cdx.NewBOMEncoder(outputWriter, outputFormat)
 	encoder.SetPretty(true)
 
-	if(outputOptions.DisableHTMLEscape) {
+	if outputOptions.DisableHTMLEscape {
 		encoder.SetEscapeHTML(false)
-	}	
+	}
 
 	if err := encoder.EncodeVersion(bom, outputVersion); err != nil {
 		return fmt.Errorf("failed to encode sbom: %w", err)


### PR DESCRIPTION
This PR adds a new ```--disable-html-escape``` CLI option to cyclonedx-gomod. When used, it disables HTML escaping in SBOM outputs. 
Ensuring raw, human-readable formats without converting special characters (e.g., & to \u0026).

### Related Issue: 

Closes issue #555 

### Example Usage:

```
cyclonedx-gomod mod -licenses -type library -json -disable-html-escape -output bom.json ./cyclonedx-go
```