### PR TITLE
fix: print hint that it is actually a Git error

### DIFF
--- a/internal/gomod/version.go
+++ b/internal/gomod/version.go
@@ -61,7 +61,7 @@ func GetModuleVersion(logger zerolog.Logger, moduleDir string) (string, error) {
 				continue
 			}
 
-			return "", err
+			return "", fmt.Errorf("git: %w", err)
 		}
 	}
 }


### PR DESCRIPTION
Hi!

I am receiving this kind of error when running cyclonedx-gomod in a mirrored (or malformed/badly cloned) git repository:

```
ERR error="failed to determine version of main module: object not found"
```

This PR adds a hint that it is actually a go-git error. Before this patch I had to guess what `object not found` means.