### PR TITLE
feature: Add -short-PURLs to omit qualifiers from generated PURLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ FLAGS
   -packages=false              Include packages
   -paths=false                 Include file paths relative to their module root
   -serial string               Serial number
+  -short-PURLs=false           Omit all qualifiers from PackageURLs
   -std=false                   Include Go standard library as component and dependency of the module
   -verbose=false               Enable verbose output
 ```
@@ -188,6 +189,7 @@ FLAGS
   -output -                    Output file path (or - for STDOUT)
   -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
   -serial string               Serial number
+  -short-PURLs=false           Omit all qualifiers from PackageURLs
   -std=false                   Include Go standard library as component and dependency of the module
   -verbose=false               Enable verbose output
   -version string              Version of the main component
@@ -222,6 +224,7 @@ FLAGS
   -output -                    Output file path (or - for STDOUT)
   -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
   -serial string               Serial number
+  -short-PURLs=false           Omit all qualifiers from PackageURLs
   -std=false                   Include Go standard library as component and dependency of the module
   -test=false                  Include test dependencies
   -type application            Type of the main component

--- a/internal/cli/cmd/app/app.go
+++ b/internal/cli/cmd/app/app.go
@@ -121,7 +121,8 @@ func Exec(options Options) error {
 		app.WithIncludePaths(options.IncludePaths),
 		app.WithIncludeStdlib(options.IncludeStd),
 		app.WithLicenseDetector(licenseDetector),
-		app.WithMainDir(options.Main))
+		app.WithMainDir(options.Main),
+		app.WithShortPURLS(options.ShortPURLs))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/bin/bin.go
+++ b/internal/cli/cmd/bin/bin.go
@@ -96,7 +96,8 @@ func Exec(options Options) error {
 		bin.WithLogger(logger),
 		bin.WithIncludeStdlib(options.IncludeStd),
 		bin.WithLicenseDetector(licenseDetector),
-		bin.WithVersionOverride(options.Version))
+		bin.WithVersionOverride(options.Version),
+		bin.WithShortPURLS(options.ShortPURLs))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/mod/mod.go
+++ b/internal/cli/cmd/mod/mod.go
@@ -89,7 +89,8 @@ func Exec(options Options) error {
 		mod.WithComponentType(cdx.ComponentType(options.ComponentType)),
 		mod.WithIncludeStdlib(options.IncludeStd),
 		mod.WithIncludeTestModules(options.IncludeTest),
-		mod.WithLicenseDetector(licenseDetector))
+		mod.WithLicenseDetector(licenseDetector),
+		mod.WithShortPURLS(options.ShortPURLs))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -117,6 +117,7 @@ type SBOMOptions struct {
 	NoSerialNumber  bool
 	ResolveLicenses bool
 	SerialNumber    string
+	ShortPURLs      bool
 }
 
 func (s *SBOMOptions) RegisterFlags(fs *flag.FlagSet) {
@@ -125,6 +126,7 @@ func (s *SBOMOptions) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.NoSerialNumber, "noserial", false, "Omit serial number")
 	fs.BoolVar(&s.ResolveLicenses, "licenses", false, "Perform license detection")
 	fs.StringVar(&s.SerialNumber, "serial", "", "Serial number")
+	fs.BoolVar(&s.ShortPURLs, "short-PURLs", false, "Omit all qualifiers from PackageURLs")
 }
 
 func (s SBOMOptions) Validate() error {

--- a/internal/gomod/module.go
+++ b/internal/gomod/module.go
@@ -86,6 +86,10 @@ func (m Module) PackageURL() string {
 	return fmt.Sprintf("pkg:golang/%s?type=module&goos=%s&goarch=%s", m.Coordinates(), envMap["GOOS"], envMap["GOARCH"])
 }
 
+func (m Module) ShortPackageURL() string {
+	return fmt.Sprintf("pkg:golang/%s", m.Coordinates())
+}
+
 // IsModule determines whether dir is a Go module.
 func IsModule(dir string) bool {
 	return util.FileExists(filepath.Join(dir, "go.mod"))

--- a/internal/sbom/convert/module/module.go
+++ b/internal/sbom/convert/module/module.go
@@ -168,6 +168,17 @@ func WithTestScope(scope cdx.Scope) Option {
 	}
 }
 
+// WithShortPURL configures the component to use short PURLs without query parameters.
+func WithShortPURL(enabled bool) Option {
+	return func(_ zerolog.Logger, module gomod.Module, component *cdx.Component) error {
+		if enabled {
+			component.PackageURL = module.ShortPackageURL()
+		}
+
+		return nil
+	}
+}
+
 // ToComponent converts a gomod.Module to a CycloneDX component.
 // The component can be further customized using options, before it's returned.
 func ToComponent(logger zerolog.Logger, module gomod.Module, options ...Option) (*cdx.Component, error) {

--- a/internal/sbom/convert/pkg/package.go
+++ b/internal/sbom/convert/pkg/package.go
@@ -82,6 +82,17 @@ func WithFiles(enabled bool, pathEnabled bool) Option {
 	}
 }
 
+// WithShortPURL configures the component to use short PURLs without query parameters.
+func WithShortPURL(enabled bool) Option {
+	return func(_ zerolog.Logger, pkg gomod.Package, module gomod.Module, component *cdx.Component) error {
+		if enabled {
+			component.PackageURL = fmt.Sprintf("pkg:golang/%s@%s", pkg.ImportPath, module.Version)
+		}
+
+		return nil
+	}
+}
+
 func ToComponent(logger zerolog.Logger, pkg gomod.Package, module gomod.Module, options ...Option) (*cdx.Component, error) {
 	logger.Debug().
 		Str("package", pkg.ImportPath).

--- a/pkg/generate/app/generator.go
+++ b/pkg/generate/app/generator.go
@@ -46,6 +46,7 @@ type generator struct {
 	licenseDetector licensedetect.Detector
 	mainDir         string
 	moduleDir       string
+	shortPURLs      bool
 }
 
 func NewGenerator(moduleDir string, opts ...Option) (generate.Generator, error) {
@@ -98,8 +99,10 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	mainComponent, err := modConv.ToComponent(g.logger, modules[0],
 		modConv.WithComponentType(cdx.ComponentTypeApplication),
 		modConv.WithLicenses(g.licenseDetector),
+		modConv.WithShortPURL(g.shortPURLs),
 		modConv.WithPackages(g.includePackages,
-			pkgConv.WithFiles(g.includeFiles, g.includePaths)),
+			pkgConv.WithFiles(g.includeFiles, g.includePaths),
+			pkgConv.WithShortPURL(g.shortPURLs)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert main module: %w", err)
@@ -118,8 +121,10 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	components, err := modConv.ToComponents(g.logger, modules[1:],
 		modConv.WithLicenses(g.licenseDetector),
 		modConv.WithModuleHashes(),
+		modConv.WithShortPURL(g.shortPURLs),
 		modConv.WithPackages(g.includePackages,
-			pkgConv.WithFiles(g.includeFiles, g.includePaths)),
+			pkgConv.WithFiles(g.includeFiles, g.includePaths),
+			pkgConv.WithShortPURL(g.shortPURLs)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert modules: %w", err)
@@ -227,7 +232,7 @@ func (g generator) includeAppPathInMainComponentPURL(bom *cdx.BOM) error {
 	mainDirRel := strings.TrimPrefix(mainDirAbs, moduleDirAbs)
 	mainDirRel = strings.TrimPrefix(mainDirRel, string(os.PathSeparator))
 
-	if mainDirRel != "" {
+	if mainDirRel != "" && !g.shortPURLs {
 		mainDirRel = strings.TrimSuffix(mainDirRel, string(os.PathSeparator))
 
 		oldPURL := bom.Metadata.Component.PackageURL

--- a/pkg/generate/app/options.go
+++ b/pkg/generate/app/options.go
@@ -88,3 +88,11 @@ func WithMainDir(dir string) Option {
 		return nil
 	}
 }
+
+// WithShortPURLS toggles the use of short PURLs without query parameters.
+func WithShortPURLS(enable bool) Option {
+	return func(g *generator) error {
+		g.shortPURLs = enable
+		return nil
+	}
+}

--- a/pkg/generate/bin/options.go
+++ b/pkg/generate/bin/options.go
@@ -76,3 +76,11 @@ func WithVersionOverride(version string) Option {
 		return nil
 	}
 }
+
+// WithShortPURLS toggles the use of short PURLs without query parameters.
+func WithShortPURLS(enable bool) Option {
+	return func(g *generator) error {
+		g.shortPURLs = enable
+		return nil
+	}
+}

--- a/pkg/generate/mod/generator.go
+++ b/pkg/generate/mod/generator.go
@@ -42,6 +42,7 @@ type generator struct {
 	includeStdlib   bool
 	includeTest     bool
 	licenseDetector licensedetect.Detector
+	shortPURLs      bool
 }
 
 // NewGenerator returns a generator that is capable of generating BOMs for Go modules.
@@ -106,6 +107,7 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	main, err := modConv.ToComponent(g.logger, modules[0],
 		modConv.WithComponentType(g.componentType),
 		modConv.WithLicenses(g.licenseDetector),
+		modConv.WithShortPURL(g.shortPURLs),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert main module: %w", err)
@@ -113,6 +115,7 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	components, err := modConv.ToComponents(g.logger, modules[1:],
 		modConv.WithLicenses(g.licenseDetector),
 		modConv.WithModuleHashes(),
+		modConv.WithShortPURL(g.shortPURLs),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert modules: %w", err)

--- a/pkg/generate/mod/options.go
+++ b/pkg/generate/mod/options.go
@@ -74,3 +74,11 @@ func WithLogger(logger zerolog.Logger) Option {
 		return nil
 	}
 }
+
+// WithShortPURLS toggles the use of short PURLs without query parameters.
+func WithShortPURLS(enable bool) Option {
+	return func(g *generator) error {
+		g.shortPURLs = enable
+		return nil
+	}
+}


### PR DESCRIPTION
Resolves #684 