### PR TITLE
Fix panic in FilterModules when processing modules with no Go source files

### DIFF
--- a/internal/gomod/filter.go
+++ b/internal/gomod/filter.go
@@ -55,7 +55,18 @@ func FilterModules(logger zerolog.Logger, moduleDir string, modules []Module, in
 
 	buf := new(bytes.Buffer)
 	filtered := make([]Module, 0)
-	chunks := chunkModules(modules, 20)
+
+	// The main module is always included; separate it out before filtering.
+	nonMain := make([]Module, 0, len(modules))
+	for _, mod := range modules {
+		if mod.Main {
+			filtered = append(filtered, mod)
+		} else {
+			nonMain = append(nonMain, mod)
+		}
+	}
+
+	chunks := chunkModules(nonMain, 20)
 
 	for _, chunk := range chunks {
 		paths := make([]string, len(chunk))

--- a/internal/gomod/filter_test.go
+++ b/internal/gomod/filter_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestParseModWhy(t *testing.T) {
-	modWhyOutput := `
+	t.Run("Mixed", func(t *testing.T) {
+		modWhyOutput := `
 # github.com/stretchr/testify
 github.com/CycloneDX/cyclonedx-gomod
 github.com/CycloneDX/cyclonedx-gomod.test
@@ -39,10 +40,22 @@ github.com/stretchr/testify/assert
 (main module does not need to vendor module bazil.org/fuse)
 `
 
-	modulePkgs := parseModWhy(strings.NewReader(modWhyOutput))
-	require.Len(t, modulePkgs, 3)
+		modulePkgs := parseModWhy(strings.NewReader(modWhyOutput))
+		require.Len(t, modulePkgs, 3)
 
-	assert.Len(t, modulePkgs["github.com/stretchr/testify"], 3)
-	assert.Len(t, modulePkgs["github.com/CycloneDX/cyclonedx-go"], 0)
-	assert.Len(t, modulePkgs["bazil.org/fuse"], 0)
+		assert.Len(t, modulePkgs["github.com/stretchr/testify"], 3)
+		assert.Len(t, modulePkgs["github.com/CycloneDX/cyclonedx-go"], 0)
+		assert.Len(t, modulePkgs["bazil.org/fuse"], 0)
+	})
+
+	t.Run("NoDirectDependencies", func(t *testing.T) {
+		modWhyOutput := `
+# github.com/CycloneDX/cyclonedx-go
+(main module does not need to vendor module github.com/CycloneDX/cyclonedx-go)
+`
+		modulePkgs := parseModWhy(strings.NewReader(modWhyOutput))
+		require.Len(t, modulePkgs, 1)
+
+		assert.Len(t, modulePkgs["github.com/CycloneDX/cyclonedx-go"], 0)
+	})
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -88,8 +88,10 @@ func RequireStdlibComponentToBeRedacted(t *testing.T, bom *cdx.BOM, expectPackag
 
 			version = component.Version
 			oldBOMRef = component.BOMRef
+			// PackageURL percent-encodes special chars in the version; BOMRef does not.
+			purlVersion := strings.ReplaceAll(version, ":", "%3A")
 			newBOMRef = strings.ReplaceAll((*bom.Components)[i].BOMRef, version, Redacted)
-			newPURL = strings.ReplaceAll((*bom.Components)[i].PackageURL, version, Redacted)
+			newPURL = strings.ReplaceAll((*bom.Components)[i].PackageURL, purlVersion, Redacted)
 
 			(*bom.Components)[i].Version = Redacted
 			(*bom.Components)[i].BOMRef = newBOMRef

--- a/pkg/generate/mod/generator.go
+++ b/pkg/generate/mod/generator.go
@@ -99,6 +99,10 @@ func (g generator) Generate() (*cdx.BOM, error) {
 		return nil, fmt.Errorf("failed to apply module graph: %w", err)
 	}
 
+	if len(modules) == 0 {
+		return nil, fmt.Errorf("no modules found")
+	}
+
 	modules[0].Version, err = gomod.GetModuleVersion(g.logger, modules[0].Dir)
 	if err != nil {
 		g.logger.Warn().Err(err).Msg("failed to determine version of main module")


### PR DESCRIPTION
Issue: https://github.com/CycloneDX/cyclonedx-gomod/issues/734

Always include the main module (mod.Main == true) without subjecting it to go mod why filtering, which would otherwise exclude it when no packages are imported

Add bounds check in generator.Generate to return an error instead of panicking when the module list is empty

Fix stdlib version redaction in test helper to percent-encode : as %3A when searching within PackageURL (which URL-encodes the version), while keeping literal matching for BOMRef

Expand TestParseModWhy into subtests; add NoDirectDependencies case where all modules are reported as unneeded by go mod why