### PR TITLE
chore: bump trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         version: latest
     - name: Scan Dockerfiles
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # tag=0.33.1
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # tag=v0.35.0
       with:
         scan-type: config
         skip-files: "Dockerfile.examples"


### PR DESCRIPTION
As per https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0