### PR TITLE
Feature: Add VersionOverride-option to application-mode

### DIFF
--- a/internal/cli/cmd/app/app.go
+++ b/internal/cli/cmd/app/app.go
@@ -121,6 +121,7 @@ func Exec(options Options) error {
 		app.WithIncludePaths(options.IncludePaths),
 		app.WithIncludeStdlib(options.IncludeStd),
 		app.WithLicenseDetector(licenseDetector),
+		app.WithVersionOverride(options.Version),
 		app.WithMainDir(options.Main),
 		app.WithShortPURLS(options.ShortPURLs))
 	if err != nil {

--- a/internal/cli/cmd/app/options.go
+++ b/internal/cli/cmd/app/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	IncludePaths    bool
 	Main            string
 	ModuleDir       string
+	Version         string
 }
 
 func (o *Options) RegisterFlags(fs *flag.FlagSet) {
@@ -52,6 +53,7 @@ func (o *Options) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.IncludePackages, "packages", false, "Include packages")
 	fs.BoolVar(&o.IncludePaths, "paths", false, "Include file paths relative to their module root")
 	fs.StringVar(&o.Main, "main", "", "Path to the application's main package, relative to MODULE_PATH")
+	fs.StringVar(&o.Version, "version", "", "Version of the application")
 }
 
 func (o Options) Validate() error {

--- a/pkg/generate/app/generator.go
+++ b/pkg/generate/app/generator.go
@@ -48,6 +48,7 @@ type generator struct {
 	mainDir         string
 	moduleDir       string
 	shortPURLs      bool
+	versionOverride string
 }
 
 func NewGenerator(moduleDir string, opts ...Option) (generate.Generator, error) {
@@ -102,9 +103,13 @@ func (g generator) Generate() (*cdx.BOM, error) {
 		return nil, fmt.Errorf("failed to apply module graph: %w", err)
 	}
 
-	modules[appModuleIndex].Version, err = gomod.GetModuleVersion(g.logger, modules[appModuleIndex].Dir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine version of main module: %w", err)
+	if g.versionOverride != "" {
+		modules[appModuleIndex].Version = g.versionOverride
+	} else {
+		modules[appModuleIndex].Version, err = gomod.GetModuleVersion(g.logger, modules[appModuleIndex].Dir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine version of main module: %w", err)
+		}
 	}
 
 	mainComponent, err := modConv.ToComponent(g.logger, modules[appModuleIndex],

--- a/pkg/generate/app/options.go
+++ b/pkg/generate/app/options.go
@@ -96,3 +96,15 @@ func WithShortPURLS(enable bool) Option {
 		return nil
 	}
 }
+
+// WithVersionOverride overrides the version of the application.
+//
+// This is useful in cases where a BOM is generated from a monorepo
+// containing multiple applications and generating version info from
+// git is not useful or not possible.
+func WithVersionOverride(version string) Option {
+	return func(g *generator) error {
+		g.versionOverride = version
+		return nil
+	}
+}

--- a/pkg/generate/app/options_test.go
+++ b/pkg/generate/app/options_test.go
@@ -64,3 +64,10 @@ func TestWithLogger(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, logger, g.logger)
 }
+
+func TestWithVersionOverride(t *testing.T) {
+	g := &generator{versionOverride: ""}
+	err := WithVersionOverride("v1.2.3")(g)
+	require.NoError(t, err)
+	require.Equal(t, "v1.2.3", g.versionOverride)
+}


### PR DESCRIPTION
This adds an VersionOverride option to `app`.

This is useful in situations where the autogenerated version from SCM is not appropriate, like in monorepos with multiple applications.

A test in `pkg/generate/app/options_test.go` is included.