### PR TITLE
fix: omit goarch/goos PURL qualifiers from mod SBOMs

### DIFF
--- a/internal/gomod/module.go
+++ b/internal/gomod/module.go
@@ -87,6 +87,13 @@ func (m Module) PackageURL() string {
 	return fmt.Sprintf("pkg:golang/%s?goarch=%s&goos=%s&type=module", m.Coordinates(), envMap["GOARCH"], envMap["GOOS"])
 }
 
+// ModulePackageURL is like PackageURL but without the goarch and goos
+// qualifiers. A module SBOM is platform independent, so it shouldn't carry
+// the build host's GOOS/GOARCH.
+func (m Module) ModulePackageURL() string {
+	return fmt.Sprintf("pkg:golang/%s?type=module", m.Coordinates())
+}
+
 func (m Module) ShortPackageURL() string {
 	return fmt.Sprintf("pkg:golang/%s", m.Coordinates())
 }

--- a/internal/sbom/convert/module/module.go
+++ b/internal/sbom/convert/module/module.go
@@ -179,6 +179,15 @@ func WithShortPURL(enabled bool) Option {
 	}
 }
 
+// WithModulePURL configures the component to use a platform-neutral module PURL,
+// dropping the goarch and goos qualifiers.
+func WithModulePURL() Option {
+	return func(_ zerolog.Logger, module gomod.Module, component *cdx.Component) error {
+		component.PackageURL = module.ModulePackageURL()
+		return nil
+	}
+}
+
 // ToComponent converts a gomod.Module to a CycloneDX component.
 // The component can be further customized using options, before it's returned.
 func ToComponent(logger zerolog.Logger, module gomod.Module, options ...Option) (*cdx.Component, error) {

--- a/pkg/generate/mod/generator.go
+++ b/pkg/generate/mod/generator.go
@@ -107,6 +107,7 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	main, err := modConv.ToComponent(g.logger, modules[0],
 		modConv.WithComponentType(g.componentType),
 		modConv.WithLicenses(g.licenseDetector),
+		modConv.WithModulePURL(),
 		modConv.WithShortPURL(g.shortPURLs),
 	)
 	if err != nil {
@@ -115,6 +116,7 @@ func (g generator) Generate() (*cdx.BOM, error) {
 	components, err := modConv.ToComponents(g.logger, modules[1:],
 		modConv.WithLicenses(g.licenseDetector),
 		modConv.WithModuleHashes(),
+		modConv.WithModulePURL(),
 		modConv.WithShortPURL(g.shortPURLs),
 	)
 	if err != nil {

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-Simple
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-Simple
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-simple",
       "version": "v0.0.0-20210716183230-c7ea7c975ab8",
-      "purl": "pkg:golang/testmod-simple@v0.0.0-20210716183230-c7ea7c975ab8?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-simple@v0.0.0-20210716183230-c7ea7c975ab8?type=module"
     }
   },
   "components": [
@@ -25,7 +25,7 @@
           "content": "a8962d5e72515a6a5eee6ff75e5ca1aec2eb11446a1d1336931ce8c57ab2503b"
         }
       ],
-      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?goarch=REDACTED\u0026goos=REDACTED\u0026type=module",
+      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?type=module",
       "externalReferences": [
         {
           "url": "https://github.com/google/uuid",
@@ -48,7 +48,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleLocal
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleLocal
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-local",
       "version": "v0.0.0-20210716185356-32d6b8adc872",
-      "purl": "pkg:golang/testmod-local@v0.0.0-20210716185356-32d6b8adc872?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-local@v0.0.0-20210716185356-32d6b8adc872?type=module"
     }
   },
   "components": [
@@ -24,7 +24,7 @@
           "content": "0fc77332094208335c4c70c9580b2a9c29ec4e7da87267a62e0dcfdc19608c85"
         }
       ],
-      "purl": "pkg:golang/testmod-local-dependency?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-local-dependency?type=module"
     },
     {
       "bom-ref": "pkg:golang/std@REDACTED?type=module",
@@ -32,7 +32,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleMultiCommand
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleMultiCommand
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-simple",
       "version": "v0.0.0-20210901192510-dc2d14d2351d",
-      "purl": "pkg:golang/testmod-simple@v0.0.0-20210901192510-dc2d14d2351d?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-simple@v0.0.0-20210901192510-dc2d14d2351d?type=module"
     }
   },
   "components": [
@@ -25,7 +25,7 @@
           "content": "a8962d5e72515a6a5eee6ff75e5ca1aec2eb11446a1d1336931ce8c57ab2503b"
         }
       ],
-      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?goarch=REDACTED\u0026goos=REDACTED\u0026type=module",
+      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?type=module",
       "externalReferences": [
         {
           "url": "https://github.com/google/uuid",
@@ -54,7 +54,7 @@
           "content": "79f58173df0efdd059460d69c36c620f3a2f9e532309af4d3e77da88176e87c2"
         }
       ],
-      "purl": "pkg:golang/github.com/package-url/packageurl-go@v0.1.0?goarch=REDACTED\u0026goos=REDACTED\u0026type=module",
+      "purl": "pkg:golang/github.com/package-url/packageurl-go@v0.1.0?type=module",
       "externalReferences": [
         {
           "url": "https://github.com/package-url/packageurl-go",
@@ -68,7 +68,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleNested
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleNested
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-simple",
       "version": "v0.0.0-20210716190707-a62fcff56e7e",
-      "purl": "pkg:golang/testmod-simple@v0.0.0-20210716190707-a62fcff56e7e?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-simple@v0.0.0-20210716190707-a62fcff56e7e?type=module"
     }
   },
   "components": [
@@ -25,7 +25,7 @@
           "content": "a8962d5e72515a6a5eee6ff75e5ca1aec2eb11446a1d1336931ce8c57ab2503b"
         }
       ],
-      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?goarch=REDACTED\u0026goos=REDACTED\u0026type=module",
+      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?type=module",
       "externalReferences": [
         {
           "url": "https://github.com/google/uuid",
@@ -48,7 +48,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleNoDependencies
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleNoDependencies
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-nodeps",
       "version": "v0.0.0-20210716190350-6880323ad03d",
-      "purl": "pkg:golang/testmod-nodeps@v0.0.0-20210716190350-6880323ad03d?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-nodeps@v0.0.0-20210716190350-6880323ad03d?type=module"
     }
   },
   "components": [
@@ -19,7 +19,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [

--- a/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleVendor
+++ b/pkg/generate/mod/testdata/snapshots/TestGenerator_Generate-SimpleVendor
@@ -9,7 +9,7 @@
       "type": "application",
       "name": "testmod-vendored",
       "version": "v0.0.0-20210716185931-5c9f3d791930",
-      "purl": "pkg:golang/testmod-vendored@v0.0.0-20210716185931-5c9f3d791930?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/testmod-vendored@v0.0.0-20210716185931-5c9f3d791930?type=module"
     }
   },
   "components": [
@@ -19,7 +19,7 @@
       "name": "github.com/google/uuid",
       "version": "v1.2.0",
       "scope": "required",
-      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?goarch=REDACTED\u0026goos=REDACTED\u0026type=module",
+      "purl": "pkg:golang/github.com/google/uuid@v1.2.0?type=module",
       "externalReferences": [
         {
           "url": "https://github.com/google/uuid",
@@ -42,7 +42,7 @@
       "name": "std",
       "version": "REDACTED",
       "scope": "required",
-      "purl": "pkg:golang/std@REDACTED?goarch=REDACTED\u0026goos=REDACTED\u0026type=module"
+      "purl": "pkg:golang/std@REDACTED?type=module"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Fixes #662. A mod SBOM is platform independent, but its component PURLs currently carry goarch/goos from the build host, so the same module produces different PURLs on different machines and PURL-based matching or dedup across SBOMs breaks. This adds a platform-neutral module PURL (Module.ModulePackageURL and a WithModulePURL converter option) and uses it in the mod generator for both the main component and dependencies, matching what the app and bin generators already do for their dependency graphs and what nscuro noted back in #148. app and bin themselves are untouched, so they still emit goos/goarch on the build-environment main component, and -short-purls still wins when it's set.

I regenerated the mod snapshots with UPDATE_SNAPSHOTS=true; the only diff is goarch/goos dropping off the mod PURLs, and go test ./pkg/generate/... plus the internal sbom/gomod tests stay green (app and bin included). Thanks for taking a look.