### PR TITLE
Add -license-confidence-threshold CLI flag for small go-modules that otherwise are not detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,22 +132,23 @@ Examples:
   $ cyclonedx-gomod app -json -output acme-app.bom.json -packages -files -licenses -main cmd/acme-app /usr/src/acme-module
 
 FLAGS
-  -assert-licenses=false       Assert detected licenses
-  -files=false                 Include files
-  -json=false                  Output in JSON
-  -disable-html-escape=false   Disable HTML escaping in JSON output
-  -licenses=false              Perform license detection
-  -main string                 Path to the application's main package, relative to MODULE_PATH
-  -noserial=false              Omit serial number
-  -notimestamp=false           Omit timestamp
-  -output -                    Output file path (or - for STDOUT)
-  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -packages=false              Include packages
-  -paths=false                 Include file paths relative to their module root
-  -serial string               Serial number
-  -short-purls=false           Omit all qualifiers from PackageURLs
-  -std=false                   Include Go standard library as component and dependency of the module
-  -verbose=false               Enable verbose output
+  -assert-licenses=false              Assert detected licenses
+  -disable-html-escape=false          Disable HTML escaping in JSON output
+  -files=false                        Include files
+  -json=false                         Output in JSON
+  -license-confidence-threshold 0.85  Minimum confidence (0.0-1.0) required for a detected license to be included
+  -licenses=false                     Perform license detection
+  -main string                        Path to the application's main package, relative to MODULE_PATH
+  -noserial=false                     Omit serial number
+  -notimestamp=false                  Omit timestamp
+  -output -                           Output file path (or - for STDOUT)
+  -output-version 1.6                 Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -packages=false                     Include packages
+  -paths=false                        Include file paths relative to their module root
+  -serial string                      Serial number
+  -short-purls=false                  Omit all qualifiers from PackageURLs
+  -std=false                          Include Go standard library as component and dependency of the module
+  -verbose=false                      Enable verbose output
 ```
 
 #### `bin`
@@ -182,18 +183,20 @@ Example:
   $ cyclonedx-gomod bin -json -output acme-app-v1.0.0.bom.json -version v1.0.0 ./acme-app
 
 FLAGS
-  -assert-licenses=false       Assert detected licenses
-  -json=false                  Output in JSON
-  -disable-html-escape=false   Disable HTML escaping in JSON output
-  -licenses=false              Perform license detection
-  -noserial=false              Omit serial number
-  -output -                    Output file path (or - for STDOUT)
-  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -serial string               Serial number
-  -short-purls=false           Omit all qualifiers from PackageURLs
-  -std=false                   Include Go standard library as component and dependency of the module
-  -verbose=false               Enable verbose output
-  -version string              Version of the main component
+  -assert-licenses=false              Assert detected licenses
+  -disable-html-escape=false          Disable HTML escaping in JSON output
+  -json=false                         Output in JSON
+  -license-confidence-threshold 0.85  Minimum confidence (0.0-1.0) required for a detected license to be included
+  -licenses=false                     Perform license detection
+  -noserial=false                     Omit serial number
+  -notimestamp=false                  Omit timestamp
+  -output -                           Output file path (or - for STDOUT)
+  -output-version 1.6                 Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -serial string                      Serial number
+  -short-purls=false                  Omit all qualifiers from PackageURLs
+  -std=false                          Include Go standard library as component and dependency of the module
+  -verbose=false                      Enable verbose output
+  -version string                     Version of the main component
 ```
 
 #### `mod`
@@ -217,19 +220,21 @@ Examples:
   $ cyclonedx-gomod mod -test -output bom.xml ./cyclonedx-go
 
 FLAGS
-  -assert-licenses=false       Assert detected licenses
-  -json=false                  Output in JSON
-  -disable-html-escape=false   Disable HTML escaping in JSON output
-  -licenses=false              Perform license detection
-  -noserial=false              Omit serial number
-  -output -                    Output file path (or - for STDOUT)
-  -output-version 1.6          Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
-  -serial string               Serial number
-  -short-purls=false           Omit all qualifiers from PackageURLs
-  -std=false                   Include Go standard library as component and dependency of the module
-  -test=false                  Include test dependencies
-  -type application            Type of the main component
-  -verbose=false               Enable verbose output
+  -assert-licenses=false              Assert detected licenses
+  -disable-html-escape=false          Disable HTML escaping in JSON output
+  -json=false                         Output in JSON
+  -license-confidence-threshold 0.85  Minimum confidence (0.0-1.0) required for a detected license to be included
+  -licenses=false                     Perform license detection
+  -noserial=false                     Omit serial number
+  -notimestamp=false                  Omit timestamp
+  -output -                           Output file path (or - for STDOUT)
+  -output-version 1.6                 Output spec verson (1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0)
+  -serial string                      Serial number
+  -short-purls=false                  Omit all qualifiers from PackageURLs
+  -std=false                          Include Go standard library as component and dependency of the module
+  -test=false                         Include test dependencies
+  -type application                   Type of the main component
+  -verbose=false                      Enable verbose output
 ```
 
 ### Examples 📃
@@ -372,6 +377,11 @@ rather than the `licenses` field directly.
 > *cyclonedx-gomod* will use the `licenses` field, instead of `evidences`. This can be
 > helpful when the generated BOM is pushed to an analysis tool that does not yet handle
 > evidences.
+
+Licenses detected with a confidence below `0.85` are discarded by default. This threshold
+can be adjusted via the `-license-confidence-threshold` flag, accepting values between `0.0` and `1.0`.
+Lowering it will surface more (potentially incorrect) license matches, while raising it
+makes detection more conservative.
 
 ### Hashes
 

--- a/internal/cli/cmd/app/app.go
+++ b/internal/cli/cmd/app/app.go
@@ -111,7 +111,7 @@ func Exec(options Options) error {
 
 	var licenseDetector licensedetect.Detector
 	if options.ResolveLicenses {
-		licenseDetector = local.NewDetector(logger)
+		licenseDetector = local.NewDetector(logger, float32(options.LicenseConfidenceThreshold))
 	}
 
 	generator, err := app.NewGenerator(options.ModuleDir,

--- a/internal/cli/cmd/bin/bin.go
+++ b/internal/cli/cmd/bin/bin.go
@@ -89,7 +89,7 @@ func Exec(options Options) error {
 
 	var licenseDetector licensedetect.Detector
 	if options.ResolveLicenses {
-		licenseDetector = local.NewDetector(logger)
+		licenseDetector = local.NewDetector(logger, float32(options.LicenseConfidenceThreshold))
 	}
 
 	generator, err := bin.NewGenerator(options.BinaryPath,

--- a/internal/cli/cmd/mod/mod.go
+++ b/internal/cli/cmd/mod/mod.go
@@ -81,7 +81,7 @@ func Exec(options Options) error {
 
 	var licenseDetector licensedetect.Detector
 	if options.ResolveLicenses {
-		licenseDetector = local.NewDetector(logger)
+		licenseDetector = local.NewDetector(logger, float32(options.LicenseConfidenceThreshold))
 	}
 
 	generator, err := mod.NewGenerator(options.ModuleDir,

--- a/internal/cli/options/options.go
+++ b/internal/cli/options/options.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/CycloneDX/cyclonedx-gomod/internal/util"
+	"github.com/CycloneDX/cyclonedx-gomod/pkg/licensedetect/local"
 )
 
 // ValidationError represents a validation error for options.
@@ -112,18 +113,21 @@ func (o OutputOptions) Validate() error {
 
 // SBOMOptions provides options for customizing the SBOM.
 type SBOMOptions struct {
-	AssertLicenses  bool
-	IncludeStd      bool
-	NoSerialNumber  bool
-	NoTimestamp     bool
-	ResolveLicenses bool
-	SerialNumber    string
-	ShortPURLs      bool
+	AssertLicenses             bool
+	IncludeStd                 bool
+	LicenseConfidenceThreshold float64
+	NoSerialNumber             bool
+	NoTimestamp                bool
+	ResolveLicenses            bool
+	SerialNumber               string
+	ShortPURLs                 bool
 }
 
 func (s *SBOMOptions) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.AssertLicenses, "assert-licenses", false, "Assert detected licenses")
 	fs.BoolVar(&s.IncludeStd, "std", false, "Include Go standard library as component and dependency of the module")
+	fs.Float64Var(&s.LicenseConfidenceThreshold, "license-confidence-threshold", local.DefaultMinDetectionConfidence,
+		"Minimum confidence (0.0-1.0) required for a detected license to be included")
 	fs.BoolVar(&s.NoSerialNumber, "noserial", false, "Omit serial number")
 	fs.BoolVar(&s.NoTimestamp, "notimestamp", false, "Omit timestamp")
 	fs.BoolVar(&s.ResolveLicenses, "licenses", false, "Perform license detection")
@@ -136,6 +140,10 @@ func (s SBOMOptions) Validate() error {
 
 	if s.AssertLicenses && !s.ResolveLicenses {
 		errs = append(errs, fmt.Errorf("assertion of licenses has no effect without licenses detection"))
+	}
+
+	if s.LicenseConfidenceThreshold < 0 || s.LicenseConfidenceThreshold > 1 {
+		errs = append(errs, fmt.Errorf("license confidence threshold: must be between 0.0 and 1.0, got %v", s.LicenseConfidenceThreshold))
 	}
 
 	// Serial numbers must be valid UUIDs

--- a/internal/cli/options/options_test.go
+++ b/internal/cli/options/options_test.go
@@ -86,4 +86,20 @@ func TestSBOMOptions_Validate(t *testing.T) {
 		require.Len(t, validationError.Errors, 1)
 		require.Contains(t, validationError.Errors[0].Error(), "serial number")
 	})
+
+	t.Run("InvalidLicenseConfidenceThreshold", func(t *testing.T) {
+		for _, threshold := range []float64{-0.1, 1.1} {
+			var options SBOMOptions
+			options.LicenseConfidenceThreshold = threshold
+
+			err := options.Validate()
+			require.Error(t, err)
+
+			var validationError *ValidationError
+			require.ErrorAs(t, err, &validationError)
+
+			require.Len(t, validationError.Errors, 1)
+			require.Contains(t, validationError.Errors[0].Error(), "license confidence threshold")
+		}
+	})
 }

--- a/pkg/generate/app/generator_test.go
+++ b/pkg/generate/app/generator_test.go
@@ -62,7 +62,7 @@ func TestGenerator_Generate(t *testing.T) {
 		fixturePath := testutil.ExtractFixtureArchive(t, "../testdata/simple.tar.gz")
 
 		g, err := NewGenerator(fixturePath,
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger),
 			WithIncludeStdlib(true))
 		require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestGenerator_Generate(t *testing.T) {
 			WithIncludeFiles(true),
 			WithIncludePackages(true),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -112,7 +112,7 @@ func TestGenerator_Generate(t *testing.T) {
 		g, err := NewGenerator(fixturePath,
 			WithIncludePackages(true),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger),
 			WithMainDir("cmd/purl"))
 		require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger),
 			WithMainDir("cmd/uuid"))
 		require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func TestGenerator_Generate(t *testing.T) {
 			WithIncludeFiles(true),
 			WithIncludePackages(true),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestGenerator_Generate(t *testing.T) {
 		g, err := NewGenerator(fixturePath,
 			WithIncludePackages(true),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 

--- a/pkg/generate/app/options_test.go
+++ b/pkg/generate/app/options_test.go
@@ -49,7 +49,7 @@ func TestWithIncludeStdlib(t *testing.T) {
 }
 
 func TestWithLicenseDetector(t *testing.T) {
-	detector := local.NewDetector(zerolog.Nop())
+	detector := local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)
 
 	g := &generator{licenseDetector: detector}
 	err := WithLicenseDetector(detector)(g)

--- a/pkg/generate/bin/generator_test.go
+++ b/pkg/generate/bin/generator_test.go
@@ -57,7 +57,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 	t.Run("Simple", func(t *testing.T) {
 		g, err := NewGenerator("../testdata/simple",
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 	t.Run("Simple1.18", func(t *testing.T) {
 		g, err := NewGenerator("../testdata/simple1.18",
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 

--- a/pkg/generate/bin/options_test.go
+++ b/pkg/generate/bin/options_test.go
@@ -35,7 +35,7 @@ func TestWithIncludeStdlib(t *testing.T) {
 }
 
 func TestWithLicenseDetector(t *testing.T) {
-	detector := local.NewDetector(zerolog.Nop())
+	detector := local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)
 
 	g := &generator{licenseDetector: nil}
 	err := WithLicenseDetector(detector)(g)

--- a/pkg/generate/mod/generator_test.go
+++ b/pkg/generate/mod/generator_test.go
@@ -61,7 +61,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -99,7 +99,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(filepath.Join(fixturePath, "local"),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(filepath.Join(fixturePath, "simple"),
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func TestGenerator_Generate(t *testing.T) {
 
 		g, err := NewGenerator(fixturePath,
 			WithIncludeStdlib(true),
-			WithLicenseDetector(local.NewDetector(zerolog.Nop())),
+			WithLicenseDetector(local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)),
 			WithLogger(testutil.SilentLogger))
 		require.NoError(t, err)
 

--- a/pkg/generate/mod/options_test.go
+++ b/pkg/generate/mod/options_test.go
@@ -50,7 +50,7 @@ func TestWithIncludeTestModules(t *testing.T) {
 }
 
 func TestWithLicenseDetector(t *testing.T) {
-	detector := local.NewDetector(zerolog.Nop())
+	detector := local.NewDetector(zerolog.Nop(), local.DefaultMinDetectionConfidence)
 
 	g := &generator{licenseDetector: nil}
 	err := WithLicenseDetector(detector)(g)

--- a/pkg/licensedetect/local/detector.go
+++ b/pkg/licensedetect/local/detector.go
@@ -31,16 +31,23 @@ import (
 	"github.com/CycloneDX/cyclonedx-gomod/pkg/licensedetect"
 )
 
-const minDetectionConfidence = 0.85
+// DefaultMinDetectionConfidence is the minimum confidence a detected license
+// must have in order to be included in the SBOM, unless overridden via NewDetector.
+const DefaultMinDetectionConfidence = 0.85
 
 type detector struct {
-	logger zerolog.Logger
+	logger                 zerolog.Logger
+	minDetectionConfidence float32
 }
 
 // NewDetector returns a license detector capable of detecting licenses locally.
-func NewDetector(logger zerolog.Logger) licensedetect.Detector {
+// minDetectionConfidence is the minimum confidence (0.0-1.0) a detected license
+// must have in order to be included in the SBOM. Licenses detected with a lower
+// confidence are discarded.
+func NewDetector(logger zerolog.Logger, minDetectionConfidence float32) licensedetect.Detector {
 	return &detector{
-		logger: logger,
+		logger:                 logger,
+		minDetectionConfidence: minDetectionConfidence,
 	}
 }
 
@@ -84,12 +91,12 @@ func (d detector) Detect(path, version, dir string) ([]cdx.License, error) {
 	if detectedLicense == "" {
 		return []cdx.License{}, nil
 	}
-	if detectedLicenseConfidence < minDetectionConfidence {
+	if detectedLicenseConfidence < d.minDetectionConfidence {
 		d.logger.Debug().
 			Str("module", fmt.Sprintf("%s@%s", path, version)).
 			Str("license", detectedLicense).
 			Float32("confidence", detectedLicenseConfidence).
-			Float32("minConfidence", minDetectionConfidence).
+			Float32("minConfidence", d.minDetectionConfidence).
 			Msg("detection confidence for license is too low")
 		return []cdx.License{}, nil
 	}

--- a/pkg/licensedetect/local/detector_test.go
+++ b/pkg/licensedetect/local/detector_test.go
@@ -27,14 +27,14 @@ import (
 
 func TestDetector_Detect(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		licenses, err := NewDetector(zerolog.Nop()).Detect("path", "version", "../../../")
+		licenses, err := NewDetector(zerolog.Nop(), DefaultMinDetectionConfidence).Detect("path", "version", "../../../")
 		require.NoError(t, err)
 		require.Len(t, licenses, 1)
 		assert.Equal(t, "Apache-2.0", licenses[0].ID)
 	})
 
 	t.Run("NoLicenseDetected", func(t *testing.T) {
-		licenses, err := NewDetector(zerolog.Nop()).Detect("path", "version", t.TempDir())
+		licenses, err := NewDetector(zerolog.Nop(), DefaultMinDetectionConfidence).Detect("path", "version", t.TempDir())
 		require.NoError(t, err)
 		require.Empty(t, licenses)
 	})


### PR DESCRIPTION
Expose the local license detector's minimum detection confidence (previously the hardcoded minDetectionConfidence = 0.85 constant) as a configurable CLI flag on the mod, app and bin commands.

This is necessary to correctly list the licenses of small go-modules that fall below that threshold. These Licenense need to be detected and included in the SBOM to fullfill NIS2 Compliance for Supply-Chain Accountability.

- pkg/licensedetect/local: NewDetector now takes a minDetectionConfidence parameter instead of relying on the package-level constant. The previous default is preserved as the exported DefaultMinDetectionConfidence.
- internal/cli/options: add LicenseConfidenceThreshold to SBOMOptions, registered as -license-confidence-threshold (default 0.85), validated to be within [0.0, 1.0].
- internal/cli/cmd/{mod,app,bin}: pass the configured threshold into local.NewDetector.
- Update README and tests accordingly.