### PR TITLE
Point the VCS URL of a nested module at its repository

### DIFF
--- a/internal/sbom/convert/module/module.go
+++ b/internal/sbom/convert/module/module.go
@@ -261,10 +261,6 @@ func ToComponents(logger zerolog.Logger, modules []gomod.Module, options ...Opti
 }
 
 var (
-	// By convention, modules with a major version equal to or above v2
-	// have it as suffix in their module path.
-	vcsUrlMajorVersionSuffixRegex = regexp.MustCompile(`(/v[\d]+)$`)
-
 	// gopkg.in with user segment
 	// Example: gopkg.in/user/pkg.v3 -> github.com/user/pkg
 	vcsUrlGoPkgInRegexWithUser = regexp.MustCompile(`^gopkg\.in/([^/]+)/([^.]+)\..*$`)
@@ -279,7 +275,7 @@ const vcsHttpsPrefix = "https://"
 func resolveVCSURL(modulePath string) string {
 	switch {
 	case strings.HasPrefix(modulePath, "github.com/"):
-		return vcsHttpsPrefix + vcsUrlMajorVersionSuffixRegex.ReplaceAllString(modulePath, "")
+		return vcsHttpsPrefix + gitHubRepositoryPath(modulePath)
 	case vcsUrlGoPkgInRegexWithUser.MatchString(modulePath):
 		return vcsHttpsPrefix + vcsUrlGoPkgInRegexWithUser.ReplaceAllString(modulePath, "github.com/$1/$2")
 	case vcsUrlGoPkgInRegexWithoutUser.MatchString(modulePath):
@@ -287,4 +283,22 @@ func resolveVCSURL(modulePath string) string {
 	}
 
 	return ""
+}
+
+// gitHubRepositoryPath reduces a GitHub module path to the path of the repository hosting it.
+// Repositories are addressed by owner and name only, so any additional segments of the module
+// path refer to a directory inside the repository and are not part of its URL. This includes
+// the major version suffix that modules with a major version equal to or above v2 carry by
+// convention.
+//
+// Example: github.com/aws/aws-sdk-go-v2/internal/ini -> github.com/aws/aws-sdk-go-v2
+func gitHubRepositoryPath(modulePath string) string {
+	const repositoryPathSegments = 3 // host, owner, repository
+
+	segments := strings.Split(modulePath, "/")
+	if len(segments) <= repositoryPathSegments {
+		return modulePath
+	}
+
+	return strings.Join(segments[:repositoryPathSegments], "/")
 }

--- a/internal/sbom/convert/module/module_test.go
+++ b/internal/sbom/convert/module/module_test.go
@@ -312,4 +312,9 @@ func TestResolveVCSURL(t *testing.T) {
 	t.Run("gopkg.in variant 2", func(t *testing.T) {
 		require.Equal(t, "https://github.com/go-check/check", resolveVCSURL("gopkg.in/check.v1"))
 	})
+
+	t.Run("GitHub with nested module", func(t *testing.T) {
+		assert.Equal(t, "https://github.com/aws/aws-sdk-go-v2", resolveVCSURL("github.com/aws/aws-sdk-go-v2/internal/ini"))
+		assert.Equal(t, "https://github.com/CycloneDX/cyclonedx-go", resolveVCSURL("github.com/CycloneDX/cyclonedx-go/pkg/sub/v2"))
+	})
 }


### PR DESCRIPTION
Closes #630.

`resolveVCSURL` strips only a trailing major-version suffix from a GitHub module path:

    vcsUrlMajorVersionSuffixRegex = regexp.MustCompile(`(/v[\d]+)$`)
    ...
    case strings.HasPrefix(modulePath, "github.com/"):
        return vcsHttpsPrefix + vcsUrlMajorVersionSuffixRegex.ReplaceAllString(modulePath, "")

Every segment below the repository therefore stays in the URL, and a nested module gets a `vcs` reference that does not resolve:

| module path | before | after |
| --- | --- | --- |
| `github.com/aws/aws-sdk-go-v2/internal/ini` | `https://github.com/aws/aws-sdk-go-v2/internal/ini` — 404 | `https://github.com/aws/aws-sdk-go-v2` |
| `github.com/CycloneDX/cyclonedx-go/pkg/sub/v2` | `https://github.com/CycloneDX/cyclonedx-go/pkg/sub` — 404 | `https://github.com/CycloneDX/cyclonedx-go` |
| `github.com/CycloneDX/cyclonedx-go` | unchanged | unchanged |
| `github.com/CycloneDX/cyclonedx-go/v2` | `https://github.com/CycloneDX/cyclonedx-go` | unchanged |

A GitHub repository is addressed by owner and name, so anything after the third segment names a directory inside it. `gitHubRepositoryPath` reduces the path to those three segments, which also covers the major-version suffix the regex used to handle — so the regex is gone rather than kept alongside.

The `gopkg.in` branches are untouched.

### Measured

On `07257d5`, `go test ./internal/sbom/convert/module/...`:

| | PASS | FAIL |
| --- | --- | --- |
| `main` | 23 | 0 |
| `main` + the new subtest, without the fix | 22 | **2** |
| with the fix | **24** | 0 |

The failure on the middle row names the defect directly:

    --- FAIL: TestResolveVCSURL/GitHub_with_nested_module
        -https://github.com/CycloneDX/cyclonedx-go
        +https://github.com/CycloneDX/cyclonedx-go/pkg/sub

I also ran a deliberate-sabotage control — setting the segment count to 99, so the helper returns the path untouched — and the suite goes to **21 PASS / 3 FAIL**, which confirms the new test actually exercises the helper rather than passing for an unrelated reason.

`go test -short ./...` across the repository: **17 packages ok, 0 failed**, identical on an untouched checkout. `gofmt -l` and `go vet` are clean on both changed files.

AI-assisted (LLM used for drafting); the measurements above are mine.
