### PR TITLE
fix: derive pseudo-versions from HEAD history

### DIFF
--- a/internal/gomod/version.go
+++ b/internal/gomod/version.go
@@ -100,8 +100,8 @@ func GetVersionFromTag(logger zerolog.Logger, moduleDir string) (string, error) 
 	return module.PseudoVersion(
 		semver.Major(latestTag.name),
 		latestTag.name,
-		latestTag.commit.Author.When,
-		latestTag.commit.Hash.String()[:12],
+		headCommit.Author.When,
+		headCommit.Hash.String()[:12],
 	), nil
 }
 

--- a/internal/gomod/version.go
+++ b/internal/gomod/version.go
@@ -138,10 +138,12 @@ func GetLatestTag(logger zerolog.Logger, repo *git.Repository, headCommit *objec
 				return err
 			}
 
-			isBeforeOrAtHead := commit.Committer.When.Before(headCommit.Author.When) ||
-				commit.Committer.When.Equal(headCommit.Committer.When)
+			isAncestor, err := commit.IsAncestor(headCommit)
+			if err != nil {
+				return err
+			}
 
-			if isBeforeOrAtHead && (latestTag.commit == nil || commit.Committer.When.After(latestTag.commit.Committer.When)) {
+			if isAncestor && (latestTag.commit == nil || commit.Committer.When.After(latestTag.commit.Committer.When)) {
 				latestTag.name = ref.Name().Short()
 				latestTag.commit = commit
 			}

--- a/internal/gomod/version_test.go
+++ b/internal/gomod/version_test.go
@@ -32,35 +32,37 @@ import (
 )
 
 func TestGetVersionFromTagPseudoVersionUsesHeadRevision(t *testing.T) {
-	repositoryDir := t.TempDir()
-	repository, err := git.PlainInit(repositoryDir, false)
-	require.NoError(t, err)
-
-	worktree, err := repository.Worktree()
-	require.NoError(t, err)
-
-	commit := func(contents string, when time.Time) plumbing.Hash {
-		require.NoError(t, os.WriteFile(filepath.Join(repositoryDir, "module.go"), []byte(contents), 0o600))
-		_, err := worktree.Add("module.go")
-		require.NoError(t, err)
-
-		signature := &object.Signature{Name: "Test", Email: "test@example.com", When: when}
-		hash, err := worktree.Commit(contents, &git.CommitOptions{Author: signature, Committer: signature})
-		require.NoError(t, err)
-		return hash
-	}
+	repositoryDir, repository, worktree := initTestRepository(t)
 
 	taggedAt := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
-	taggedHash := commit("tagged", taggedAt)
-	_, err = repository.CreateTag("v1.2.3", taggedHash, nil)
+	taggedHash := commitTestFile(t, repositoryDir, worktree, "tagged", taggedAt)
+	_, err := repository.CreateTag("v1.2.3", taggedHash, nil)
 	require.NoError(t, err)
 
 	headAt := taggedAt.Add(time.Hour)
-	headHash := commit("head", headAt)
+	headHash := commitTestFile(t, repositoryDir, worktree, "head", headAt)
 
 	version, err := GetVersionFromTag(zerolog.Nop(), repositoryDir)
 	require.NoError(t, err)
 	require.Equal(t, module.PseudoVersion("v1", "v1.2.3", headAt, headHash.String()[:12]), version)
+}
+
+func TestGetVersionFromTagIgnoresUnreachableTags(t *testing.T) {
+	repositoryDir, repository, worktree := initTestRepository(t)
+
+	baseAt := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	baseHash := commitTestFile(t, repositoryDir, worktree, "base", baseAt)
+	taggedHash := commitTestFile(t, repositoryDir, worktree, "tagged", baseAt.Add(time.Hour))
+	_, err := repository.CreateTag("v1.2.3", taggedHash, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, worktree.Reset(&git.ResetOptions{Mode: git.HardReset, Commit: baseHash}))
+	headAt := baseAt.Add(2 * time.Hour)
+	headHash := commitTestFile(t, repositoryDir, worktree, "head", headAt)
+
+	version, err := GetVersionFromTag(zerolog.Nop(), repositoryDir)
+	require.NoError(t, err)
+	require.Equal(t, module.PseudoVersion("v0", "", headAt, headHash.String()[:12]), version)
 }
 
 func TestGetLatestTag(t *testing.T) {
@@ -78,4 +80,29 @@ func TestGetLatestTag(t *testing.T) {
 
 	require.Equal(t, "v0.3.0", tag.name)
 	require.Equal(t, "a20be9f00d406e7b792973ee1826e637e58a23d7", tag.commit.Hash.String())
+}
+
+func initTestRepository(t *testing.T) (string, *git.Repository, *git.Worktree) {
+	t.Helper()
+
+	repositoryDir := t.TempDir()
+	repository, err := git.PlainInit(repositoryDir, false)
+	require.NoError(t, err)
+
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+	return repositoryDir, repository, worktree
+}
+
+func commitTestFile(t *testing.T, repositoryDir string, worktree *git.Worktree, contents string, when time.Time) plumbing.Hash {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(repositoryDir, "module.go"), []byte(contents), 0o600))
+	_, err := worktree.Add("module.go")
+	require.NoError(t, err)
+
+	signature := &object.Signature{Name: "Test", Email: "test@example.com", When: when}
+	hash, err := worktree.Commit(contents, &git.CommitOptions{Author: signature, Committer: signature})
+	require.NoError(t, err)
+	return hash
 }

--- a/internal/gomod/version_test.go
+++ b/internal/gomod/version_test.go
@@ -18,13 +18,50 @@
 package gomod
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/module"
 )
+
+func TestGetVersionFromTagPseudoVersionUsesHeadRevision(t *testing.T) {
+	repositoryDir := t.TempDir()
+	repository, err := git.PlainInit(repositoryDir, false)
+	require.NoError(t, err)
+
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+
+	commit := func(contents string, when time.Time) plumbing.Hash {
+		require.NoError(t, os.WriteFile(filepath.Join(repositoryDir, "module.go"), []byte(contents), 0o600))
+		_, err := worktree.Add("module.go")
+		require.NoError(t, err)
+
+		signature := &object.Signature{Name: "Test", Email: "test@example.com", When: when}
+		hash, err := worktree.Commit(contents, &git.CommitOptions{Author: signature, Committer: signature})
+		require.NoError(t, err)
+		return hash
+	}
+
+	taggedAt := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	taggedHash := commit("tagged", taggedAt)
+	_, err = repository.CreateTag("v1.2.3", taggedHash, nil)
+	require.NoError(t, err)
+
+	headAt := taggedAt.Add(time.Hour)
+	headHash := commit("head", headAt)
+
+	version, err := GetVersionFromTag(zerolog.Nop(), repositoryDir)
+	require.NoError(t, err)
+	require.Equal(t, module.PseudoVersion("v1", "v1.2.3", headAt, headHash.String()[:12]), version)
+}
 
 func TestGetLatestTag(t *testing.T) {
 	repo, err := git.PlainClone(t.TempDir(), false, &git.CloneOptions{


### PR DESCRIPTION
## Summary

Fix pseudo-version generation for untagged revisions.

Previously, version detection:

- Used the base tag's timestamp and hash instead of those from HEAD.
- Considered tags from unrelated branches based only on commit timestamps.

This could produce an SBOM component version that identified the wrong revision or used an unreachable tag as its pseudo-version base.

This change:

- Uses HEAD's timestamp and hash when constructing a pseudo-version.
- Considers a semantic-version tag only when its commit is an ancestor of HEAD.
- Adds regression tests for both cases using local Git repositories.

Fixes #419.

## Verification

- `go test -short ./...`
- `golangci-lint run ./internal/gomod/...`
- `git diff --check`